### PR TITLE
feat: redirect authenticated users from homepage to dashboard

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,23 @@
-import { clerkMiddleware } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
 
-export default clerkMiddleware()
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
+
+export default clerkMiddleware(async (auth, req) => {
+  // Protect dashboard routes
+  if (isProtectedRoute(req)) {
+    await auth.protect()
+  }
+
+  // Redirect authenticated users from homepage to dashboard
+  if (req.nextUrl.pathname === '/') {
+    const { userId } = await auth()
+    if (userId) {
+      const dashboardUrl = new URL('/dashboard', req.url)
+      return NextResponse.redirect(dashboardUrl)
+    }
+  }
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
When users who are logged in try to access the main homepage (/), they will now be automatically redirected to /dashboard.

This implementation:
- Checks authentication status in middleware
- Redirects authenticated users from / to /dashboard
- Maintains route protection for dashboard routes
- Follows routing guidelines from /docs/routing.md

Fixes #4