### PR TITLE
fix: add navigation to workout details page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -154,9 +154,11 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
                         </span>
                       </div>
                       <div className="pt-4">
-                        <Button variant="outline" className="w-full">
-                          View Details
-                        </Button>
+                        <Link href={`/dashboard/workout/${workout.id}`}>
+                          <Button variant="outline" className="w-full">
+                            View Details
+                          </Button>
+                        </Link>
                       </div>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
Fixes #9

## Summary
Wrap View Details button with Next.js Link component to enable navigation to `/dashboard/workout/[workoutId]` when clicked.

## Changes
- Modified `app/dashboard/page.tsx` to wrap the "View Details" button with `<Link>` component
- Button now navigates to `/dashboard/workout/${workout.id}` on click

## Test Plan
- Navigate to `/dashboard`
- Click "View Details" on any workout card
- Verify navigation to the workout details page

Generated with [Claude Code](https://claude.ai/code)